### PR TITLE
Preserve indentation in code blocks

### DIFF
--- a/src/commandCodeLensProvider.ts
+++ b/src/commandCodeLensProvider.ts
@@ -6,14 +6,15 @@ export class CommandCodeLensProvider implements vscode.CodeLensProvider {
     provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
         var codeLenses = [];
         const lines = document.getText().split('\n');
-
         var inCommand = false;
         var currentCommand = '';
         var commandStartLine = 0;
+
         for (var i = 0; i < lines.length; i++) {
-            const line = lines[i].trim();
+            const line = lines[i];
+
             if (inCommand) {
-                if (line === '```') {
+                if (line.trim() === '```') {
                     const cmd: vscode.Command = {
                         title: 'Run command in terminal',
                         command: 'markdown.run.command',
@@ -26,12 +27,10 @@ export class CommandCodeLensProvider implements vscode.CodeLensProvider {
                     currentCommand = '';
                     continue;
                 }
-
                 currentCommand += line + '\n';
                 continue;
             }
-
-            if (line.startsWith('```') || line.startsWith('```sh') || line.startsWith('```bash')) {
+            if (line.trim().startsWith('```') || line.trim().startsWith('```sh') || line.trim().startsWith('```bash')) {
                 inCommand = true;
                 commandStartLine = i;
                 continue;
@@ -43,6 +42,5 @@ export class CommandCodeLensProvider implements vscode.CodeLensProvider {
     resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens> {
         return null;
     }
-
 
 }


### PR DESCRIPTION
I want to keep indentation inside code blocks to allow use cases such as creating file content with significant whitespace:

```sh
cat << EOF > format_json.py
#!/usr/bin/env python3
import sys
import json

def main():
    input_data = sys.stdin.read()

    try:
        parsed_data = json.loads(input_data)
    except json.JSONDecodeError:
        print("Error: Input is not valid JSON", file=sys.stderr)
        sys.exit(1)

    json.dump(parsed_data, sys.stdout, indent=4)

if __name__ == "__main__":
    main()
EOF
```